### PR TITLE
Added EXPOSE directive to Dockerfiles

### DIFF
--- a/Dockerfile.source.alsa
+++ b/Dockerfile.source.alsa
@@ -4,6 +4,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 ENV LANG C.UTF-8
+EXPOSE 12101
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \

--- a/Dockerfile.source.alsa.pizero
+++ b/Dockerfile.source.alsa.pizero
@@ -3,6 +3,7 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 
 ENV LANG C.UTF-8
+EXPOSE 12101
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \


### PR DESCRIPTION
[`EXPOSE`](https://docs.docker.com/engine/reference/builder/#expose) is used by projects like [`nginx-proxy`](https://github.com/nginx-proxy/nginx-proxy) in order to automatically detect which ports the container uses.