### PR TITLE
Fix some dependencies not getting installed

### DIFF
--- a/scripts/create-venv.sh
+++ b/scripts/create-venv.sh
@@ -57,7 +57,7 @@ fi
 
 # Opengrm
 opengrm_file="${download}/opengrm-1.3.4-${target_arch}.tar.gz"
-if [[ -n "$(command -v ngramcount)" ]]; then
+if [[ -z "$(command -v ngramcount)" ]]; then
     echo 'Installing Opengrm'
     "${src_dir}/scripts/install-opengrm.sh" \
         "${opengrm_file}" \
@@ -72,7 +72,7 @@ fi
 
 # Phonetisaurus
 phonetisaurus_file="${download}/phonetisaurus-2019-${target_arch}.tar.gz"
-if [[ -n "$(command -v phonetisaurus-apply)" ]]; then
+if [[ -z "$(command -v phonetisaurus-apply)" ]]; then
     echo 'Installing Phonetisaurus'
     "${src_dir}/scripts/install-phonetisaurus.sh" \
         "${phonetisaurus_file}" \

--- a/scripts/create-venv.sh
+++ b/scripts/create-venv.sh
@@ -40,7 +40,7 @@ pip3 ${PIP_INSTALL} wheel setuptools
 # Snowboy
 if [[ -s "${download}/snowboy-1.3.0.tar.gz" ]]; then
     # Only install if not already present in venv
-    if [[ -z "$(pip3 freeze | grep '^snowboy==1.2.0b1$')" ]]; then
+    if ! pip3 freeze | grep -q '^snowboy==1.2.0b1$'; then
         echo 'Installing snowboy'
         pip3 ${PIP_INSTALL} "${download}/snowboy-1.3.0.tar.gz"
     fi
@@ -50,7 +50,7 @@ fi
 if [[ -s "${download}/pocketsphinx-python.tar.gz" ]]; then
     echo 'Installing pocketsphinx'
     # Only install if not already present in venv
-    if [[ -z "$(pip3 freeze | grep '^pocketsphinx==0.1.15$')" ]]; then
+    if ! pip3 freeze | grep -q '^pocketsphinx==0.1.15$'; then
         pip3 ${PIP_INSTALL} "${download}/pocketsphinx-python.tar.gz"
     fi
 fi


### PR DESCRIPTION
"ngramcount" and "phonetisaurus-apply" were not getting installed when they were missing because the conditions were flipped.

```
if [[ -n "$(command -v ngramcount)" ]]; then
      ^^
```

`-n` returns 0 when "the length of STRING is nonzero" (quote from the man page). But `command -v` returns an empty string when the command was not found. I switched `-n` with `-z` which is the opposite of `-n`.

I also optimised two conditions by using `grep -q` which stops at the first matching line (see also https://github.com/koalaman/shellcheck/wiki/SC2143).