### PR TITLE
Add TTS Wavenet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -122,3 +122,6 @@
 	path = rhasspy-snips-nlu
 	url = https://github.com/rhasspy/rhasspy-snips-nlu
 	branch = master
+[submodule "tts-wavenet-hermes"]
+	path = tts-wavenet-hermes
+	url = https://github.com/Romkabouter/rhasspy-tts-wavenet-hermes


### PR DESCRIPTION
I have the TTS Wavenet added as a submodule on my own github url, I think it should be moved to rhasspy/rhasspy-tts-wavenet-hermes but I do not now how.
Please advise