### PR TITLE
Edit intent handling MQTT topic, remove 's' to '/intent'

### DIFF
--- a/docs/intent-handling.md
+++ b/docs/intent-handling.md
@@ -4,7 +4,7 @@ After a voice command has been transcribed and your intent has been successfully
 
 You can also handle intents by:
 
-* Listening for `hermes/intents/<intentName>` messages over MQTT ([details](intent-recognition.md#mqtthermes))
+* Listening for `hermes/intent/<intentName>` messages over MQTT ([details](intent-recognition.md#mqtthermes))
 * Connecting a websocket to `/api/events/intent` ([details](reference.md#websocket-api))
 
 Available intent handling systems are:


### PR DESCRIPTION
There is a typing error in the documentation, for the MQTT topic for intent handling.

It should be `hermes/intent/<intentName>` instead of `hermes/intents/<intentName>`.

I found the error thanks to https://community.rhasspy.org/t/connection-to-mqtt-server-doesnt-happen/1555