### PR TITLE
Remove warning about maryttys effects not supported in 2.5.

### DIFF
--- a/docs/text-to-speech.md
+++ b/docs/text-to-speech.md
@@ -158,8 +158,6 @@ To save memory when running on a Raspberry Pi, considering [restricting the load
 
 ### Audio Effects
 
-**Not supported yet in 2.5!**
-
 MaryTTS is capable of applying several audio effects when producing speech.  See the web interface at [http://localhost:59125](http://localhost:59125)
 to experiment with this.
 


### PR DESCRIPTION
Doc update related to this other PR: https://github.com/rhasspy/rhasspy-supervisor/pull/6
