### PR TITLE
Add docker-compose pulseaudio user example

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -91,7 +91,7 @@ When the `SetLightColor` intent is recognized, the JSON event will contain a `co
 
 #### Tag Synonyms
 
-Tag/named entity values can be (substituted](#substitutions) using the colon (`:`) inside the `{curly:braces}` like:
+Tag/named entity values can be [substituted](#substitutions) using the colon (`:`) inside the `{curly:braces}` like:
 
 ```
 turn on the (living room lamp){name:light_1}

--- a/examples/docker-compose-pulseaudio/99-pulseaudio-default.conf
+++ b/examples/docker-compose-pulseaudio/99-pulseaudio-default.conf
@@ -1,0 +1,14 @@
+# Default to PulseAudio
+
+pcm.!default {
+    type pulse
+    hint {
+        show on
+        description "Default ALSA Output (currently PulseAudio Sound Server)"
+    }
+}
+
+ctl.!default {
+    type pulse
+}
+

--- a/examples/docker-compose-pulseaudio/README.md
+++ b/examples/docker-compose-pulseaudio/README.md
@@ -1,0 +1,21 @@
+The `docker-compose.yml` runs Rhasspy container that is connected to Pulseaudio.
+As a regular user that has Pulseaudio running you can execute
+`CURRENT_UID=$(id -u):$(id -g) docker-compose up`. It will start the docker container
+as the same user as current user and setup Rhasspy available on http://localhost:12101 .
+
+The `rhasspy.service` is a user systemd service file, that allows to execute Rhasspy upon
+user login from systemd. To use it:
+
+- Copy the contents of this directory to some custom chosen directory,
+  for example to `~/.config/rhasspy/docker-compose`.
+- Copy `rhasspy.service` to `~/.config/systemd/user/`.
+- Edit `rhasspy.service` in `~/.config/systemd/user/` and change `WorkingDirectory`
+  to the directory you copied `docker-compose.yml` into. You can use `%h` for
+  user home directory, see https://www.freedesktop.org/~#Specifiers . for example:
+  `WorkingDirectory=%h/.config/rhasspy/docker-compose`.
+- Refresh Systemd `systemctl daemon-reload --user`.
+- Then enable the service `systemctl enable --user rhasspy`.
+- Then start the service `systemctl start --user rhasspy`.
+
+
+

--- a/examples/docker-compose-pulseaudio/docker-compose.yml
+++ b/examples/docker-compose-pulseaudio/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.0"
+services:
+  rhasspy:
+    image: rhasspy/rhasspy
+    container_name: rhasspy
+    # Pass CURRENT_UID from environment variables, use 1000:1000 by default.
+    # It will run the user inside docker as this user, instead of root.
+    # It is meant to be run like:
+    #     CURRENT_UID=$(id -u):$(id -g) docker-compose up
+    user: ${CURRENT_UID:-1000:1000}
+    environment:
+      # Provide user-writable home directory
+      - HOME=/tmp
+      - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
+      - PULSE_RUNTIME_PATH=${XDG_RUNTIME_DIR}/pulse
+    volumes:
+      - /etc/localtime:/etc/localtime:ro
+      # Tell alsa to use Pulseaudio.
+      - ./99-pulseaudio-default.conf:/etc/alsa/conf.d/99-pulseaudio-default.conf:ro
+      # Provide files to connect to Pulseaudio
+      - ${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native:ro
+      - $HOME/.config/pulse/cookie:/tmp/.config/pulse/cookie:ro
+      # Link user configuration.
+      - $HOME/.config/rhasspy/profiles:/tmp/.config/rhasspy/profiles
+    ports:
+      - 12101:12101 # http
+      - 12183:12183 # mqtt
+    command: --profile en
+

--- a/examples/docker-compose-pulseaudio/rhasspy.service
+++ b/examples/docker-compose-pulseaudio/rhasspy.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Run Rhasspy user service
+Documentation=https://rhasspy.readthedocs.io/en/latest
+Documentation=https://github.com/rhasspy/rhasspy
+
+[Service]
+WorkingDirectory=%h/.config/rhasspy/docker-compose
+Environment=CURRENT_UID=%U:%G
+ExecStartPre=/usr/bin/docker-compose pull -q
+ExecStart=/usr/bin/docker-compose up
+ExecStop=/usr/bin/docker-compose down
+
+[Install]
+WantedBy=default.target
+


### PR DESCRIPTION
So I spent some time to setup a docker-compose with Rhasspy that would use my user Pulseaudio connection and create user-editable files and auto-start with system startup and would work on single-user system setup and I guess wanted to share it. There are no code changes here.