### PR TITLE
Remove debug prints to stderr

### DIFF
--- a/examples/homeassistant/profile/slot_programs/hass/entities
+++ b/examples/homeassistant/profile/slot_programs/hass/entities
@@ -45,7 +45,7 @@ curl -X GET \
     while read -r entity_id friendly_name;
     do
         # Debug to stderr
-        echo "${entity_id} ${friendly_name}" >&2
+        # echo "${entity_id} ${friendly_name}" >&2
 
         if [[ ! -z "$1" ]]; then
             # Filter based on domain


### PR DESCRIPTION
Sending stuff to stderr seems to still pick it up as valid output in the rest of the system, causing the filtering to not work correctly