### PR TITLE
Corrected pronunciation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Rhasspy 2.5 logo](docs/img/rhasspy25.png)
 
-Rhasspy (ɹˈæspi) is an [open source](https://github.com/rhasspy), fully offline set of [voice assistant services](#services) for [many human languages](#supported-languages) that works well with:
+Rhasspy (ˈɹæspi) is an [open source](https://github.com/rhasspy), fully offline set of [voice assistant services](#services) for [many human languages](#supported-languages) that works well with:
 
 * [Hermes protocol](https://docs.snips.ai/reference/hermes) compatible services ([Snips.AI](https://snips.ai/))
 * [Home Assistant](https://www.home-assistant.io/) and [Hass.io](https://www.home-assistant.io/hassio/)


### PR DESCRIPTION
The current pronunciation guide showing "ɹˈæspi" would equate to "er ASS pee". The corrected pronunciation guide would equate to the American English pronunciation of the word "raspy".