### PR TITLE
Add docker-compose example to OpenTTS docs

### DIFF
--- a/docs/text-to-speech.md
+++ b/docs/text-to-speech.md
@@ -222,6 +222,16 @@ services:
       - 5500:5500
 ```
 
+To run OpenTTS with a specific command executed (in this example, excluding `eSpeak` (robotic voices)), add:
+```yaml
+services:
+  opentts:
+    image: synesthesiam/opentts
+    ports:
+      - 5500:5500
+    command: '--no-espeak'
+```
+
 To run the full suite of text to speech systems offered by OpenTTS, add:
 
 ```yaml


### PR DESCRIPTION
Update to the Rhasspy documentation only:
- Add a docker-compose example to run OpenTTS with a specific command, to assist users in deploying OpenTTS
