### PR TITLE
Update entities script to allow for exclusions

### DIFF
--- a/examples/homeassistant/profile/slot_programs/hass/entities
+++ b/examples/homeassistant/profile/slot_programs/hass/entities
@@ -31,6 +31,14 @@ url="${url%/}"
 # Long-lived access token
 token="$(jq --raw-output .home_assistant.access_token < "${profile}")"
 
+# Create array of excluded entities from line items in file
+excluded_entities_file="${RHASSPY_PROFILE_DIR}/slot_programs/hass/excluded_entities"
+exclude_list=()
+
+if [[ -f "${excluded_entities_file}" ]]; then
+    readarray -t exclude_list < "${excluded_entities_file}"
+fi
+
 # -----------------------------------------------------------------------------
 
 # Use REST api to list the states of all Home Assistant entities.
@@ -51,9 +59,9 @@ curl -X GET \
             # Filter based on domain
             for domain in "$@";
             do
-                # Check if entity id starts with domain and a dot
+                # Check if entity id starts with domain and a dot and is not in the exclusion list
                 domain_regex="^${domain}\."
-                if [[ "${entity_id}" =~ $domain_regex ]]; then
+                if [[ "${entity_id}" =~ $domain_regex && ! "${exclude_list[@]}" =~ "${entity_id}" ]]; then
                     echo "${friendly_name}"
                     break
                 fi


### PR DESCRIPTION
When setting up Rhasspy, I realized there are some entities I didn't want to be voice activated, and I couldn't find a way to prevent them from being added to the entity list, so I modified this script slightly to check if "${RHASSPY_PROFILE_DIR}/slot_programs/hass/excluded_entities" exists, and populate an array of excluded entities from it. 

I created the "excluded_entities" file at the aforementioned location and added the entities I personally wanted to exclude, each as a line item in the file. Then, I expanded the IF check in line 62 to determine if the entity_id could be found in the array of excluded entities. If the entity_id isn't found in the array of exclusions, then it can be added.

This has been tested and is working well in my Rhasspy setup. I hope this small change might be helpful to some folks.