### PR TITLE
Update 'http-satellite' example in docs

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -599,7 +599,7 @@ The satellite web UI will be accessible at http://rhasspy-satellite:12101 where 
 
 #### Satellite Settings
 
-On your satellite, set the speech to text, intent recognition, and (optionally) the text to speech services to "Remote HTTP". Make sure to also set "Dialogue Management" to "Rhasspy", and enable audio recording, wake word, and audio playing.
+On your satellite, start by changing your "siteId" in the Settings to "satellite. Afterwards, set the speech to text, intent recognition, and (optionally) the text to speech services to "Remote HTTP". Make sure to also set "Dialogue Management" to "Rhasspy", and enable audio recording, wake word, and audio playing.
 
 ![Satellite settings for remote HTTP](img/master-satellite/satellite-http-settings.png)
 
@@ -616,6 +616,10 @@ Your base station needs to have speech to text, intent recognition, and (optiona
 ![Base station settings for remote HTTP](img/master-satellite/master-http-settings.png)
 
 You do not need to run a dialogue manager on the base station, since wake/ASR/NLU coordinate will be done on the satellite.
+
+Under **each service**, add the site id of *each* of your satellites to the "Satellite siteIds" text box (separated by commas). This will cause that particular service to response to HTTP requests coming from that satellite.
+
+![Base station satellite ids for remote HTTP](img/master-satellite/master-http-satellite-ids.png)
 
 #### Testing
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -694,7 +694,7 @@ For your base station, also set MQTT to "External" and configure the details of 
 
 ![Base station settings for Hermes MQTT](img/master-satellite/master-mqtt-settings.png)
 
- Under **each service** (including Dialogue Management), add the site id of *each* of your satellites to the "Satellite siteIds" text box (separated by commas). This will cause that particular service to response to MQTT messages coming from that satellite.
+Under **each service** (including Dialogue Management), add the site id of *each* of your satellites to the "Satellite siteIds" text box (separated by commas). This will cause that particular service to response to MQTT messages coming from that satellite.
 
 ![Base station satellite ids for Hermes MQTT](img/master-satellite/master-mqtt-satellite-ids.png)
 


### PR DESCRIPTION
This PR updates 'http-satellite' example in the docs. I experienced the issue https://github.com/rhasspy/rhasspy/issues/236, and solution was mentioned there:)

However I wasn't able to set up my local env correctly(tried both in arch and raspberry os, but got stucked at different levels), so I couldnt run `make docs` command.